### PR TITLE
Add capability to parse for slow tests

### DIFF
--- a/junorunner/runner.py
+++ b/junorunner/runner.py
@@ -12,5 +12,6 @@ class JunoDiscoverRunner(DiscoverRunner):
         return TextTestRunner(
             verbosity=self.verbosity,
             failfast=self.failfast,
-            total_tests=len(suite._tests)
+            total_tests=len(suite._tests),
+            slow_test_count=self.slow_test_count
         ).run(suite)

--- a/junorunner/testrunner.py
+++ b/junorunner/testrunner.py
@@ -16,10 +16,27 @@ class TestSuiteRunner(JunoDiscoverRunner):
 
     """
 
+    def __init__(self, *args, **kwargs):
+        self.slow_test_count = int(kwargs.get('slow_test_count', 0))
+        super(TestSuiteRunner, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def add_arguments(cls, parser):
+        super(TestSuiteRunner, cls).add_arguments(parser)
+        parser.add_argument('-s', '--slow-tests',
+            action='store',
+            dest='slow_test_count',
+            default=0,
+            help="Print given number of slowest tests"
+        )
+
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         """
         Run the unit tests for all the test labels in the provided list.
         """
+
+
+
         self.setup_test_environment()
         suite = self.build_suite(test_labels, extra_tests)
 


### PR DESCRIPTION
This adds a `--slow-tests=5` option to the test runner.
It builds a list of the slowest tests, then outputs that at the end of the test run.

Unsure about the output format, maybe could be prettier, in line with the rest of the output, happy to change it.

Accidentally closes https://github.com/yunojuno/django-juno-testrunner/issues/12 that I've just seen after I wrote this!