### PR TITLE
Update travis and tox config so it actually tests against Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: python
 python:
   - "2.7"
-# command to install tox depdendency, which then knows how to install any other dependencies
-install: "pip install tox==1.8.1"
+  - "3.4"
+
+# command to install tox depdendency, which then knows how to install
+# any other dependencies
+install: "pip install tox-travis"
+
 # command to run tests
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
-envlist = django1611_py27, django178_py27, django182_py27, django1611_py34, django178_py34, django182_py34
+envlist = django{1611,178,182}_{py27,py34}
 
+[tox:travis]
+2.7 = py27
+3.4 = py34
 
 [testenv:django1611_py27]
 basepython=python
@@ -37,5 +40,3 @@ basepython=python3
 deps =
     Django==1.8.2
 commands = python3.4 manage.py test test_app --verbosity=2
-
-


### PR DESCRIPTION
As current pip fails to run with the installed Python 3.2, I have moved the travis settings from directly using `tox` to [`tox-travis`](https://pypi.python.org/pypi/tox-travis). This will create one more test environment, though, but I don’t think it’s actually a problem.