### PR TITLE
Add support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
 
 # command to install tox depdendency, which then knows how to install
 # any other dependencies

--- a/README.rst
+++ b/README.rst
@@ -80,13 +80,11 @@ or ::
 
     $ ./manage.py test $(< test_rerun.txt)  # bash
 
-(At YunoJuno, we run our test suites via Fabric, with a ``:rerun`` option that reads in the file and passes each line — i.e. each bad test — as an extra arg to the test client.)
 
 Roadmap
 -------
 
 - improve time-left-to-run estimate
-- support use on < Django 1.6 (the code exists in another repo's history, it just needs some dusting off)
 
 Contributing
 ------------

--- a/junorunner/runner.py
+++ b/junorunner/runner.py
@@ -7,11 +7,22 @@ class JunoDiscoverRunner(DiscoverRunner):
     The only real difference between this and the standard DiscoverRunner in Django 1.6+
     is the use of the custom TextTestRunner, which we hook in via run_suite()
     """
+    def get_test_count(self, suite):
+        """
+        When running tests in parallel, a core suite is generated to contain a collection of
+        sub-suites that are then ran in parallel.
+
+        In that case we have to go and retrieve the count from each of the sub-suites as
+        the parent will not directly contain the tests.
+        """
+        if getattr(self, 'parallel', 1) > 1:
+            return sum([len(subsuite._tests) for subsuite in suite.subsuites])
+        return len(suite._tests)
 
     def run_suite(self, suite, **kwargs):
         return TextTestRunner(
             verbosity=self.verbosity,
             failfast=self.failfast,
-            total_tests=len(suite._tests),
+            total_tests=self.get_test_count(suite),
             slow_test_count=self.slow_test_count
         ).run(suite)

--- a/junorunner/testrunner.py
+++ b/junorunner/testrunner.py
@@ -34,13 +34,10 @@ class TestSuiteRunner(JunoDiscoverRunner):
         """
         Run the unit tests for all the test labels in the provided list.
         """
-
-
-
         self.setup_test_environment()
         suite = self.build_suite(test_labels, extra_tests)
 
-        print("%i tests found" % len(suite._tests))
+        print("%i tests found" % self.get_test_count(suite))
 
         old_config = self.setup_databases()
         result = self.run_suite(suite)

--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,20 @@ import sys
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_app.settings")
 
-    from django.core.management import execute_from_command_line
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django
+        except ImportError:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            )
+        raise
 
     execute_from_command_line(sys.argv)

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -6,6 +6,13 @@ class JunorunnerTestCase(TestCase):
     def test_can_run_tests(self):
         pass
 
+    def test_counts_tests_correctly(self):
+        """
+        Added this test to make sure the number of tests != number of test cases
+        (so that we can assert the total count is correct when running tests in parallel)
+        """
+        pass
+
 
 class JunorunnerTransactionTestCase(TransactionTestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
+    {1.9,1.10}: tblib==1.3.0
 commands =
     {envpython} manage.py test test_app --verbosity=2
     {envpython} manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
+    {1.9,1.10}: {envpython} manage.py test test_app --verbosity=2 --parallel 2

--- a/tox.ini
+++ b/tox.ini
@@ -1,70 +1,20 @@
 [tox]
-envlist = django{1611,178,182,196}_{py27,py34}
+envlist =
+    py27-{1.6,1.7,1.8,1.9},
+    py34-{1.6,1.7,1.8,1.9},
+    py35-{1.8,1.9},
 
 [tox:travis]
 2.7 = py27
 3.4 = py34
+3.5 = py35
 
-[testenv:django1611_py27]
-basepython=python
+[testenv]
 deps =
-    Django==1.6.11
+    1.6: Django>=1.6,<1.7
+    1.7: Django>=1.7,<1.8
+    1.8: Django>=1.8,<1.9
+    1.9: Django>=1.9,<1.10
 commands =
-    python2.7 manage.py test test_app --verbosity=2
-    python2.7 manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
-
-[testenv:django178_py27]
-basepython=python
-deps =
-    Django==1.7.8
-commands =
-    python2.7 manage.py test test_app --verbosity=2
-    python2.7 manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
-
-[testenv:django182_py27]
-basepython=python
-deps =
-    Django==1.8.2
-commands =
-    python2.7 manage.py test test_app --verbosity=2
-    python2.7 manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
-
-[testenv:django196_py27]
-basepython=python
-deps =
-    Django==1.9.6
-commands =
-    python2.7 manage.py test test_app --verbosity=2
-    python2.7 manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
-
-[testenv:django1611_py34]
-basepython=python3
-deps =
-    Django==1.6.11
-commands =
-    python3.4 manage.py test test_app --verbosity=2
-    python3.4 manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
-
-[testenv:django178_py34]
-basepython=python3
-deps =
-    Django==1.7.8
-commands =
-    python3.4 manage.py test test_app --verbosity=2
-    python3.4 manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
-
-[testenv:django182_py34]
-basepython=python3
-deps =
-    Django==1.8.2
-commands =
-    python3.4 manage.py test test_app --verbosity=2
-    python3.4 manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
-
-[testenv:django196_py34]
-basepython=python3
-deps =
-    Django==1.9.6
-commands =
-    python3.4 manage.py test test_app --verbosity=2
-    python3.4 manage.py test test_app --verbosity=2 --settings=test_app.settings_junit
+    {envpython} manage.py test test_app --verbosity=2
+    {envpython} manage.py test test_app --verbosity=2 --settings=test_app.settings_junit

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py27-{1.6,1.7,1.8,1.9},
-    py34-{1.6,1.7,1.8,1.9},
-    py35-{1.8,1.9},
+    py27-{1.6,1.7,1.8,1.9,1.10},
+    py34-{1.6,1.7,1.8,1.9,1.10},
+    py35-{1.8,1.9,1.10},
 
 [tox:travis]
 2.7 = py27
@@ -15,6 +15,7 @@ deps =
     1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
+    1.10: Django>=1.10,<1.11
 commands =
     {envpython} manage.py test test_app --verbosity=2
     {envpython} manage.py test test_app --verbosity=2 --settings=test_app.settings_junit


### PR DESCRIPTION
This contains a few more changes and improvements than the title suggests:

* Cleanup tox config, add support for python 3.5.x.
  Remove duplication from tox.ini so that it's easier
  to set up additional environments.

* Add support for python 3.5 (tested on 3.5.1), but only for
  latest django versions (1.8.6+).

* Update manage.py to match latest django template.

* Add Django 1.10 to tox tests.

* Add support for --parallel flag for Django 1.9+.
  This required fixing how we get the total test count.

  When running tests in parallel, a core suite is generated to
  contain a collection of sub-suites that are then ran in parallel.

  In that case we have to go and retrieve the count from each
  of the sub-suites as the parent will not directly contain the tests.

* Remove redundant info from the README.